### PR TITLE
Add check for man pages and output valid commands

### DIFF
--- a/history-diff.sh
+++ b/history-diff.sh
@@ -36,11 +36,13 @@ diff_cmds=$(comm -23 <(echo "$teacher_cmds" | sort) <(echo "$my_cmds" | sort))
 # Display commands used by teachers but not by the user
 echo "Commands used by teachers but not by you:"
 echo "$diff_cmds" | while read -r cmd; do
-man "$cmd" > isCommand 2>/dev/null
-if [[ -s isCommand ]]; then
+man "$cmd" > isCommandInMan 2>/dev/null
+type "$cmd" > isCommandInType 2>/dev/null
+if grep -q "builtin" isCommandInType; then
+        echo "$cmd"
+elif [[ -s isCommandInMan ]]; then
 	echo "$cmd"
 fi
-> isCommand
 done
 
 # If 'full' argument is provided, show full command history diff
@@ -48,7 +50,7 @@ if $show_full; then
     # Find full commands used by teachers but not by the user
     diff_history=$(comm -23 <(echo "$teacher_history" | sort) <(echo "$my_history" | sort))
 
-    echo "Full Commands used by teacher but not by you:"
+    echo "Full Comimands used by teacher but not by you:"
     echo "$diff_history"
 
     # Extract and display unique commands from the full history diff

--- a/history-diff.sh
+++ b/history-diff.sh
@@ -37,11 +37,10 @@ diff_cmds=$(comm -23 <(echo "$teacher_cmds" | sort) <(echo "$my_cmds" | sort))
 echo "Commands used by teachers but not by you:"
 echo "$diff_cmds" | while read -r cmd; do
 man "$cmd" > isCommandInMan 2>/dev/null
-type "$cmd" > isCommandInType 2>/dev/null
-if grep -q "builtin" isCommandInType; then
-        echo "$cmd"
+if command -v "$cmd" &> /dev/null; then
+    echo "$cmd"
 elif [[ -s isCommandInMan ]]; then
-	echo "$cmd"
+    echo "$cmd"
 fi
 done
 

--- a/history-diff.sh
+++ b/history-diff.sh
@@ -35,7 +35,13 @@ diff_cmds=$(comm -23 <(echo "$teacher_cmds" | sort) <(echo "$my_cmds" | sort))
 
 # Display commands used by teachers but not by the user
 echo "Commands used by teachers but not by you:"
-echo "$diff_cmds"
+echo "$diff_cmds" | while read -r cmd; do
+man "$cmd" > isCommand 2>/dev/null
+if [[ -s isCommand ]]; then
+	echo "$cmd"
+fi
+> isCommand
+done
 
 # If 'full' argument is provided, show full command history diff
 if $show_full; then


### PR DESCRIPTION
## Changes Description:

Added a check to verify the existence of man pages for each command.
Commands with existing man pages are printed to the screen, while commands without man pages are ignored.

### Loop for command validation:
- In each iteration of the loop, the man page for a command is requested, and the output is saved to a file.
- Errors from the man command are redirected to /dev/null to avoid unnecessary error output when a command doesn’t have a man page.
- If the file contains data (the man page exists), the command is printed to the console.
- A mechanism for clearing the file after each check was added to prevent data accumulation.